### PR TITLE
Expose POST data to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ of 200 (OK) even if your scripts didn't work.  This is intentional, to avoid cau
 errors in external services like Docker or Github, which might not like you returning
 statuses other than 200 (OK).
 
+### Accessing the Request POST Body 
+You'll sometimes need to access the POST data of the request for information such as a callback URL. 
+You can pass the raw POST data to a script by adding {{POST}} to the script arguments.
+
+```json
+{
+    "scripts": [
+        {
+            "command": "echo",
+            "args": [
+            "{{POST}}"
+            ]
+        }
+    ]
+}
+``` 
+
 ## Install
 
 `go get github.com/bketelsen/captainhook`
@@ -86,7 +103,6 @@ go build .
 ```
 ## To Do
 
-- consider making the POST data from the webhook available in some way
 - more logs
 
 

--- a/hook.go
+++ b/hook.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
@@ -18,6 +20,7 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), 500)
 		return
 	}
+	interoplatePOSTData(rb, r)
 	response, err := rb.execute()
 	if err != nil {
 		log.Println(err.Error())
@@ -30,5 +33,24 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 			log.Println(err.Error())
 		}
 		w.Write(data)
+	}
+}
+
+func interoplatePOSTData(rb *runBook, r *http.Request) {
+	if r.ContentLength == 0 {
+		return
+	}
+	data := make([]byte, r.ContentLength)
+	_, err := r.Body.Read(data)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+		return
+	}
+	defer r.Body.Close()
+	stringData := string(data[:r.ContentLength])
+	for i := range rb.Scripts {
+		for j := range rb.Scripts[i].Args {
+			rb.Scripts[i].Args[j] = strings.Replace(rb.Scripts[i].Args[j], "{{POST}}", stringData, -1)
+		}
 	}
 }


### PR DESCRIPTION
This PR addresses issue #8 by allowing the POST body to be exposed to scripts by adding {{POST}} to the config file's args JSON. For example:

```json
{
    "scripts": [
        {
            "command": "/Users/kelcecil/captainhook/get_callback.rb",
            "args": [
            "{{POST}}"
            ]
        }
    ]
}
```

I've also added a unit test to hook_test.go to cover this behavior.