### PR TITLE
Hooks should define allowed networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ You can pass the raw POST data to a script by adding {{POST}} to the script argu
 }
 ``` 
 
+### Limiting access for webhooks
+You can limit who can call your webhooks by specifying "allowedNetworks" in the json config.
+
+```json
+{
+    "scripts": [
+        {
+            "command": "echo"
+        }
+    ],
+    "allowedNetworks": [
+        "10.0.0.0/8",
+        "127.0.0.1/32"
+    ]
+}
+```
+This would allow your hook to be called from the 10.0.0.0/8 network, or from localhost.
+
 ## Install
 
 `go get github.com/bketelsen/captainhook`

--- a/hook.go
+++ b/hook.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 
@@ -18,6 +19,12 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Println(err.Error())
 		http.Error(w, err.Error(), 500)
+		return
+	}
+	remoteIP := net.ParseIP(strings.Split(r.RemoteAddr, ":")[0])
+	if !rb.AddrIsAllowed(remoteIP) {
+		log.Printf("Hook id '%s' is not allowed from %v\n", id, r.RemoteAddr)
+		http.Error(w, "Not authorized.", http.StatusUnauthorized)
 		return
 	}
 	interoplatePOSTData(rb, r)

--- a/hook_test.go
+++ b/hook_test.go
@@ -26,6 +26,21 @@ var hookHandlerScript = `
   ]
 }`
 
+var hookHandlerScriptDenied = `
+{
+  "scripts": [
+    {
+      "command": "echo",
+      "args": [
+        "foo"
+      ]
+    }
+  ],
+  "allowedNetworks": [
+    "10.0.0.0/8"
+  ]
+}`
+
 var hookResponseBody = `{
   "results": [
     {
@@ -69,6 +84,7 @@ var hookHanderTests = []struct {
 	postBody   io.Reader
 }{
 	{"", false, hookHandlerScript, 200, nil},
+	{"Not authorized.\n", false, hookHandlerScriptDenied, 401, nil},
 	{hookResponseBody, true, hookHandlerScript, 200, nil},
 	{exposePostResponseBody, true, exposePostHandlerScript, 200, bytes.NewBuffer(data)},
 }

--- a/runbook_test.go
+++ b/runbook_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+)
+
+var allowedNetworksSuccessScript = `
+{
+  "scripts": [
+    {
+      "command": "echo"
+    }
+  ],
+  "allowedNetworks": [
+    "127.0.0.1/32",
+    "10.0.0.0/8"
+  ]
+}`
+
+var allowedNetworksFailureScript = `
+{
+  "scripts": [
+    {
+      "command": "echo"
+    }
+  ],
+  "allowedNetworks": [
+    "127.0.0.1/32",
+    "10.0"
+  ]
+}`
+
+func TestNetworkUnmarshalling(t *testing.T) {
+	r := runBook{}
+	err := json.Unmarshal([]byte(allowedNetworksSuccessScript), &r)
+	if err != nil {
+		t.Errorf("JSON unmarshalling of allowed sources failed: %v", err)
+	}
+	if len(r.AllowedNetworks.Networks) != 2 {
+		t.Errorf("JSON unmarshalling didn't produce the correct result: %v", r)
+	}
+
+	r = runBook{}
+	err = json.Unmarshal([]byte(allowedNetworksFailureScript), &r)
+	if err == nil {
+		t.Errorf("JSON unmarshalling of allowed sources unexpectedly succeeded: %v", r)
+	}
+}
+
+func TestAddrIsAllowed(t *testing.T) {
+	testIPs := []struct {
+		ip     net.IP
+		result bool
+	}{
+		{net.ParseIP("127.0.0.1"), true},
+		{net.ParseIP("172.16.0.1"), false},
+		{net.ParseIP("10.0.0.1"), true},
+		{net.ParseIP("10.0.1.1"), false},
+	}
+
+	nets := make([]net.IPNet, 2)
+	for i, cidr := range []string{"127.0.0.1/32", "10.0.0.0/24"} {
+		_, ipnet, _ := net.ParseCIDR(cidr)
+		nets[i] = *ipnet
+	}
+
+	r := runBook{AllowedNetworks: Networks{Networks: nets}}
+
+	for _, testIP := range testIPs {
+		if r.AddrIsAllowed(testIP.ip) != testIP.result {
+			t.Errorf("AddrIsAllowed %v expected %v", testIP.ip, testIP.result)
+		}
+	}
+
+}


### PR DESCRIPTION
This adds limiting access to runBooks by CIDR netblocks. If "allowedNetworks" in the runBook config is not specified, the hook is implicitly allowed from 0.0.0.0/0. If specified, only IPs in those networks can call the runBook.

The json unmarshalling of the netblocks is a little hairy but I didn't see a better way to do it. Thoughts?
-o