### PR TITLE
Guarantee entire request body read in

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"io"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -47,8 +48,7 @@ func interoplatePOSTData(rb *runBook, r *http.Request) {
 	if r.ContentLength == 0 {
 		return
 	}
-	data := make([]byte, r.ContentLength)
-	_, err := r.Body.Read(data)
+	data, err := ioutil.ReadAll(r.Body)
 	if err != nil && err != io.EOF {
 		log.Fatal(err)
 		return


### PR DESCRIPTION
`ioutil.ReadAll` may not be the most efficient way to do this, but it is true that `request.Body.Read` will sometimes not read the entire request body, particularly on large requests such as those from Github webhooks (6500 bytes!).

This will guarantee that the entire request body is read in.