### PR TITLE
docker: use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
-FROM golang:1.4.2-onbuild
+# Docker multi-stage build file
+# Requires docker 17.05 or newer.
+
+FROM golang:1.4.2-onbuild as builder
 VOLUME /config
 CMD app -listen-addr 0.0.0.0:8080 -configdir /config
+
+
+FROM ubuntu:16.04
+COPY --from=builder /go/bin/app /usr/local/bin/captainhook
+ENTRYPOINT ["/usr/local/bin/captainhook"]


### PR DESCRIPTION
This reduces the docker image from ~500mb to ~130mb

I didn't drop in docker, kubectl, or docker-compose since everyone has
their own needs.

Closes #21